### PR TITLE
ci: fix release workflow auth (built-in GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,15 +14,17 @@ env:
 jobs:
   create_release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v2
         env:
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           make_latest: true
 


### PR DESCRIPTION
The `create_release` job used a custom `secrets.TOKEN` PAT that no longer has access, so tagging `v0.1.10` failed with `Resource not accessible by integration` and the dependent `build_and_push` job was skipped — no image was built.

Switch to the built-in `GITHUB_TOKEN` with an explicit `permissions: contents: write`, removing the dependency on a manually-maintained/expiring PAT. Also bump `actions/checkout` v3 → v4 to clear the Node 20 deprecation warning. The `build_and_push` job already uses the built-in token for ghcr login, so it is unchanged.