### PR TITLE
fix: key token ownership on bucket, not description (multi-service clobber)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ The init container does not produce any direct outputs. However, it results in t
 InfluxDB only returns an authorization's secret token value **once, in the
 create response** — a later `GET /api/v2/authorizations` returns that field
 empty. The script therefore cannot recover the value of a pre-existing token.
-On each run it looks up the authorization it owns (by description) and:
+On each run it looks up the authorization it owns — keyed on write access to
+its bucket, which stays unique even when several services share an
+`INFLUXDB_USER` — and:
 
 - reuses the token only if a usable value is available (i.e. just created);
 - otherwise deletes the stale/unrecoverable authorization(s) and creates a

--- a/init-influxdb.sh
+++ b/init-influxdb.sh
@@ -49,18 +49,20 @@ TOKEN_DIR=${TOKEN_DIR:-/shared/influxdb}
 # Get the organization ID
 ORG_ID=$(influx org list --name "$INFLUXDB_ORG" --hide-headers --host "${INFLUXDB_HOST}" --token "${INFLUX_TOKEN}" | cut -f 1)
 
-# Description that uniquely identifies the authorization this script owns.
-# We match on the description (not on bucket permissions) so every lookup and
-# rotation is scoped to *this* service's token and never touches tokens owned
-# by other services that happen to write to the same bucket.
-TOKEN_DESC="service-token-${INFLUXDB_USER}"
+# Label for the authorization this script creates. The bucket is included so
+# the description is unique even when several services share an INFLUXDB_USER.
+TOKEN_DESC="service-token-${INFLUXDB_USER}-${INFLUXDB_BUCKET}"
 
-# Return a JSON array of the authorization(s) this script owns.
+# Return a JSON array of the authorization(s) this script owns. Ownership is
+# keyed on *write access to this bucket* (resource.id), which is the only value
+# that is reliably unique per service — multiple services often share an
+# INFLUXDB_USER (and therefore a description) but each writes its own bucket.
+# Matching on the bucket avoids one service deleting another service's token.
 fetch_owned_auths() {
     curl -s -X GET "${INFLUXDB_HOST}/api/v2/authorizations" \
       -H "Authorization: Token ${INFLUX_TOKEN}" \
-    | jq --arg desc "$TOKEN_DESC" \
-        '[.authorizations[]? | select(.description == $desc)]' 2>/dev/null || echo '[]'
+    | jq --arg bid "$BUCKET_ID" \
+        '[.authorizations[]? | select(.status == "active") | select(.permissions[]? | .action == "write" and .resource.id == $bid)]' 2>/dev/null || echo '[]'
 }
 
 # Create a fresh scoped authorization and echo its token. InfluxDB only ever


### PR DESCRIPTION
Follow-up to #2. v0.1.10 matched the owned authorization by description `service-token-<USER>`. When multiple services share an `INFLUXDB_USER` but write **different buckets** — as reefofthings `sensors` (→ `sensor_data`) and `equipment` (→ `equipment_data`) do, both user `rot-prod` — the descriptions collide, so each service's init deleted the other's authorization (`rotating (1 stale)`) and the loser got 401 / `token required`.

Fix: key ownership on **write access to the bucket** (`resource.id`), which is unique per service. The created authorization keeps a bucket-qualified description for clarity.

Tested: bucket-scoping isolates each service (no cross-clobber); the v0.1.10 empty-token restart fix still rotates+recreates and writes a valid token.